### PR TITLE
OptimizedATM

### DIFF
--- a/ATMLibrary/AutomatedTellerMachine.cs
+++ b/ATMLibrary/AutomatedTellerMachine.cs
@@ -1,28 +1,22 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ATMLibrary
 {
     public class AutomatedTellerMachine
     {
         public delegate void BankOperationsHandler(AutomatedTellerMachine sender, BankOperationsEventArgs e);
-
         public event BankOperationsHandler Notify;
 
-        public int ATM_ID { get; protected set;}
-        public double ATM_Balance { get; set;}
-        public string ATM_Name { get; protected set;}
+        public int ATM_ID { get; }
+        public double ATM_Balance { get; private set; }
+        public string ATM_Name { get; }
 
-
-        public AutomatedTellerMachine(int atm_ID, double atm_Balance, string atm_Name) 
-        { 
+        public AutomatedTellerMachine(int atm_ID, double atm_Balance, string atm_Name)
+        {
             ATM_ID = atm_ID;
             ATM_Balance = atm_Balance;
             ATM_Name = atm_Name;
-
         }
 
         private bool ValidateSum(double sum)
@@ -35,78 +29,49 @@ namespace ATMLibrary
             return true;
         }
 
-        public void Deposit(double sum, Account[] accounts, int user) 
+        private bool HasSufficientFunds(double sum, double balance)
         {
-            if (!ValidateSum(sum)) return;
-
-            if (ATM_Balance < sum)
+            if (balance < sum)
             {
-                Notify?.Invoke(this, new BankOperationsEventArgs("Технічні проблеми. Недостатньо готівки в банкоматі(.", sum));
-            }
-
-            if (accounts[user].Balance >= sum)
-            {
-                accounts[user].Balance += sum;
-                ATM_Balance -= sum;
-                Notify?.Invoke(this, new BankOperationsEventArgs($"Знято {sum} UAH з рахунку", sum));
-            }
-
-            else
-            {
-                Notify?.Invoke(this, new BankOperationsEventArgs("Недостатньо коштів на рахунку", sum));
-            }
-        }
-
-        public void Withdraw(double sum, Account[] accounts, int user)
-        {
-            if (!ValidateSum(sum)) return;
-
-            if (ATM_Balance < sum)
-            {
-                Notify?.Invoke(this, new BankOperationsEventArgs("Технічні проблеми. Недостатньо готівки в банкоматі.", sum));
-                return;
-            }
-
-            if (accounts[user].Balance >= sum)
-            {
-                accounts[user].Balance -= sum;
-                ATM_Balance -= sum;
-                Notify?.Invoke(this, new BankOperationsEventArgs($"Знято {sum} UAH з рахунку", sum));
-            }
-            else
-            {
-                Notify?.Invoke(this, new BankOperationsEventArgs("Недостатньо коштів на рахунку", sum));
-            }
-        }
-
-
-
-
-        public bool Transfer(double sum, string cardNumber, Account[] accounts, int user)
-        {
-            if (!ValidateSum(sum)) return false;
-
-            if (accounts[user].Balance < sum)
-            {
-                Notify?.Invoke(this, new BankOperationsEventArgs("Недостатньо коштів на рахунку", sum));
+                Notify?.Invoke(this, new BankOperationsEventArgs("Недостатньо коштів", sum));
                 return false;
             }
+            return true;
+        }
 
-            Account recipient = Array.Find(accounts, acc => acc.CardNumber == cardNumber);
+        public void Deposit(double sum, Account account)
+        {
+            if (!ValidateSum(sum) || !HasSufficientFunds(sum, ATM_Balance)) return;
 
-            if (recipient != null)
-            {
-                accounts[user].Balance -= sum;
-                recipient.Balance += sum;
-                Notify?.Invoke(this, new BankOperationsEventArgs($"{sum} UAH було перераховано на картку {cardNumber}", sum));
-                return true;
-            }
-            else
+            account.Balance += sum;
+            ATM_Balance -= sum;
+            Notify?.Invoke(this, new BankOperationsEventArgs($"Зараховано {sum} UAH на рахунок", sum));
+        }
+
+        public void Withdraw(double sum, Account account)
+        {
+            if (!ValidateSum(sum) || !HasSufficientFunds(sum, account.Balance) || !HasSufficientFunds(sum, ATM_Balance)) return;
+
+            account.Balance -= sum;
+            ATM_Balance -= sum;
+            Notify?.Invoke(this, new BankOperationsEventArgs($"Знято {sum} UAH з рахунку", sum));
+        }
+
+        public bool Transfer(double sum, string cardNumber, Account senderAccount, Account[] accounts)
+        {
+            if (!ValidateSum(sum) || !HasSufficientFunds(sum, senderAccount.Balance)) return false;
+
+            var recipient = accounts.FirstOrDefault(acc => acc.CardNumber == cardNumber);
+            if (recipient == null)
             {
                 Notify?.Invoke(this, new BankOperationsEventArgs($"Картку {cardNumber} не знайдено", sum));
                 return false;
             }
+
+            senderAccount.Balance -= sum;
+            recipient.Balance += sum;
+            Notify?.Invoke(this, new BankOperationsEventArgs($"Перераховано {sum} UAH на картку {cardNumber}", sum));
+            return true;
         }
     }
-
 }


### PR DESCRIPTION
Closes #9 

Removed common checks in ValidateSum and HasSufficientFunds, which reduces the number of repetitions.
Instead of Account[] accounts, Account account is passed where required Deposit and Withdraw work with a specific Account object, without array indexes.
Optimization of account search in Transfer Used FirstOrDefault() instead of Array.Find().
Added private set; for ATM_Balance This makes it impossible to change the balance of the ATM from the outside.